### PR TITLE
Compile down to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "noImplicitAny": false,
     "outDir": ".",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
+    "lib": ["es2015"],
     "noImplicitAny": false,
     "outDir": ".",
     "sourceMap": true,


### PR DESCRIPTION
This project can't be used by people who compile their project down to es5 or lower, because of the error: `TypeError: Class constructor EventEmitter cannot be invoked without 'new'`

Please accept this so people who need to support legacy JavaScript (especially browsers) can use your library.