### PR TITLE
Make methods more type safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.d.ts
 *.js
 *.map
+.idea

--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,9 @@
  * EALINGS IN THE SOFTWARE.                                                   *
  ******************************************************************************/
 
+type EventHandler<Args extends any[]> = (...args: Args) => void;
+type EventBinder<Args extends any[]> = (event: EventHandler<Args>) => Listener;
+
 export class EventEmitter {
   private eventListeners: Map<Function, Function[]>;
   
@@ -29,7 +32,7 @@ export class EventEmitter {
     this.eventListeners = new Map();
   }
   
-  on(event: Function, listener: Function) {
+  on<Args extends any[]>(event: EventBinder<Args>, listener: EventHandler<Args>) {
     if(!this.eventListeners.has(event)) {
       this.eventListeners.set(event, [ listener ]);
     } else {
@@ -39,7 +42,7 @@ export class EventEmitter {
     return new Listener(this, event, listener);
   }
   
-  addListener(event: Function, listener: Function) {
+  addListener<Args extends any[]>(event: EventBinder<Args>, listener: EventHandler<Args>) {
     return this.on(event, listener);
   }
   
@@ -70,7 +73,7 @@ export class EventEmitter {
   /**
    * Emit event. Calls all bound listeners with args.
    */
-  protected emit(event: Function, ...args) {
+  protected emit<Args extends any[]>(event: EventBinder<Args>, ...args: Args) {
     if(this.eventListeners.has(event)) {
       for(var listener of this.eventListeners.get(event)) {
         listener(...args);
@@ -81,8 +84,8 @@ export class EventEmitter {
   /**
    * @typeparam T The event handler signature.
    */
-  registerEvent<T extends Function>() {
-    let eventBinder = (handler: T) => {
+  registerEvent<Args extends any[]>() {
+		const eventBinder: EventBinder<Args> = handler => {
       return this.addListener(eventBinder, handler);
     };
     

--- a/index.ts
+++ b/index.ts
@@ -84,8 +84,8 @@ export class EventEmitter {
   /**
    * @typeparam T The event handler signature.
    */
-  registerEvent<Args extends any[]>() {
-		const eventBinder: EventBinder<Args> = handler => {
+  registerEvent<T extends EventHandler<any[]>>() {
+    const eventBinder = (handler: T): Listener => {
       return this.addListener(eventBinder, handler);
     };
     

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Alternative event emitter for JavaScript and TypeScript.",
   "main": "index.js",
   "scripts": {
-    "prepublish": "tsc"
+    "prepare": "tsc"
   },
   "keywords": [
     "event-emitter",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": ">=1.5"
+    "typescript": ">=3.0"
   },
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "README.md"
   ]
 }


### PR DESCRIPTION
I noticed that I can put pretty much anything in a call to `.emit()` and the typings would be okay with it, so I decided to update the types of all the relevant methods to fix that.

This change requires TypeScript 3.0 ([relevant release note](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#rest-elements-in-tuple-types)). Also, it re-purposes the type parameter of `registerEvent`. Thus, it should be a major version bump.