### PR TITLE
add es2015 module generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.js
 *.map
 .idea
+es

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {
-    "prepare": "tsc && tsc -p tsconfig.json -m es2015 --outDir es -declaration false"
+    "prepare": "tsc && tsc -p tsconfig.json -m es2015 --outDir es -d false"
   },
   "keywords": [
     "event-emitter",
@@ -29,6 +29,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "es/*",
     "README.md"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "2.0.0",
   "description": "Alternative event emitter for JavaScript and TypeScript.",
   "main": "index.js",
+  "module": "es/index.js",
   "scripts": {
-    "prepare": "tsc"
+    "prepare": "tsc && tsc -p tsconfig.json -m es2015 --outDir es -declaration false"
   },
   "keywords": [
     "event-emitter",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,11 @@
     "noImplicitAny": false,
     "outDir": ".",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "types": [],
   },
   "files": [
     "index.ts"
-  ]
+  ],
+  "exclude": ["./node_modules/**"]
 }


### PR DESCRIPTION
Additionally transpile into an es2015 module so projects will not need to convert this module into ES6 (e.g. rollup-plugin-commonjs for Rollup).